### PR TITLE
Fix a bug that users cannot remove their gold pass

### DIFF
--- a/src/BCSFE_Python/edits/other/get_gold_pass.py
+++ b/src/BCSFE_Python/edits/other/get_gold_pass.py
@@ -101,6 +101,8 @@ def get_gold_pass(save_stats: dict[str, Any]) -> dict[str, Any]:
     )
     if officer_id == "":
         officer_id = get_random_officer_id()
+    elif officer_id == "-1":
+        officer_id = -1
     else:
         officer_id = helper.check_int_max(officer_id)
 


### PR DESCRIPTION
When I try to remove my gold pass to prevent be ban, I discovered I input -1 but the script always received as 0.