### PR TITLE
Fixing syntax error in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ colored==1.4.4
 PyJWT==2.10.1
 PyYAML==6.0.2
 Requests==2.32.4
-beautifulsoup4=4.13.4
+beautifulsoup4==4.13.4
 argparse==1.4.0


### PR DESCRIPTION
There needs to be another equal sign on line 6 for the beautifulsoup requirement